### PR TITLE
Use latest zlib

### DIFF
--- a/nginx-build.sh
+++ b/nginx-build.sh
@@ -584,10 +584,9 @@ _download_zlib() {
             echo "### configure zlib-cf ###"
             ./configure --prefix=/usr/local/zlib-cf
         else
-            echo "### downloading zlib 1.2.12 ###"
+            echo "### downloading zlib latest ###"
             rm -rf zlib
-            curl -sL http://zlib.net/zlib-1.2.12.tar.gz | /bin/tar zxf - -C "$DIR_SRC"
-            mv zlib-1.2.12 zlib
+            curl -sL https://zlib.net/current/zlib.tar.gz | /bin/tar zxf - -C "$DIR_SRC"
         fi
 
     } >>/tmp/nginx-ee.log 2>&1; then


### PR DESCRIPTION
The installation of zlib fails because version 1.2.13 is no longer available for download. To resolve this issue, it is recommended to use a permalink that automatically directs to the most recent version of zlib. This ensures that you always have access to the latest features and security updates without encountering download errors due to outdated links.
